### PR TITLE
Flag default image as a Template

### DIFF
--- a/AnyBar/AppDelegate.m
+++ b/AnyBar/AppDelegate.m
@@ -30,7 +30,9 @@ static const int UdpPortMax = 65535;
     NSImage *defaultImage = [NSImage imageNamed:DefaultImageName];
     NSImage *warnImage = [NSImage imageNamed:NSImageNameStatusUnavailable];
     int port = -1;
-
+    
+    defaultImage.Template = YES;
+    
     self.statusItem = [self initializeStatusBarItem];
     [self updateStatusImage: defaultImage];
 


### PR DESCRIPTION
Hi there!

I'm using the dark theme and neither white, black and alternate icons are visible.

This commit fixes at least default icon, so when you first run the app you will see icon.

So it is visible with the dark theme of the menu bar:

![as is](https://dl.dropboxusercontent.com/u/5761606/as_is.png) ![fixed](https://dl.dropboxusercontent.com/u/5761606/fixed.png)
