### PR TITLE
Added anybar-icon-journal link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ $ anybar red
 $ anybar green 1739
 ```
 
+Bash alias with journaling:
+
+- [Andrew565/anybar-icon-journal](https://github.com/Andrew565/anybar-icon-journal)
+
 Go:
 
 - [justincampbell/anybar](https://github.com/justincampbell/anybar)


### PR DESCRIPTION
I created a set of bash functions and aliases to support using AnyBar as a journal from the command line. Would love to make your users more aware of it!
