### PR TITLE
Add with_anybar tool to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Alfred:
 - Webpack build status plugin [roman01la/anybar-webpack](https://github.com/roman01la/anybar-webpack)
 - boot-clj task [tonsky/boot-anybar](https://github.com/tonsky/boot-anybar)
 - Anybar-based CLI journal [Andrew565/anybar-icon-journal](https://github.com/Andrew565/anybar-icon-journal)
+- Command monitoring [rvirani1/with_anybar](https://github.com/rvirani1/with_anybar)
 
 ## Running multiple instances
 


### PR DESCRIPTION
I wrote a simple tool that updates anybar based on the status of a command. Very useful for monitoring a script or some other long running command when it's not on screen. 
