### PR TITLE
Fix dead Homebrew Cask link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Version 0.1.4:
 
 <a href="https://github.com/tonsky/AnyBar/releases/download/0.1.4/AnyBar-0.1.4.zip"><img src="AnyBar/Images.xcassets/AppIcon.appiconset/icon_128x128@2x.png?raw=true" style="width: 128px;" width=128/></a>
 
-Or using [Homebrew-cask](http://caskroom.io):
+Or using [Homebrew Cask](https://github.com/Homebrew/homebrew-cask):
 
     brew cask install anybar
 


### PR DESCRIPTION
The current link of http://caskroom.io currently goes to a spam site and not the Cask project page. I changed it to the Homebrew Cask GitHub repo, though if you'd prefer the [Cask site](https://formulae.brew.sh/cask/) I can change it to that.