### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Version 0.2.2:
 
 Or using [Homebrew Cask](https://github.com/Homebrew/homebrew-cask):
 
-    brew cask install anybar
+    brew install --cask anybar
 
 ## Support us
 


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but README.md needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103186759-2dfab000-4905-11eb-84c4-fca6b9945b7a.png)
